### PR TITLE
Replaced heap_alloc_caps header by esp_heap_caps; changed to malloc() -  added 16bit length fields

### DIFF
--- a/main/WebSocket_Task.c
+++ b/main/WebSocket_Task.c
@@ -74,8 +74,8 @@ err_t WS_write_data(char* p_data, size_t length) {
 	if (WS_conn == NULL)
 		return ERR_CONN;
 
-	//currently only frames with a payload length <WS_STD_LEN are supported
-	if (length > WS_STD_LEN)
+	//currently only 16bit length field is supported
+	if (length > 0xFFFF)
 		return ERR_VAL;
 
 	//netconn_write result buffer
@@ -84,10 +84,20 @@ err_t WS_write_data(char* p_data, size_t length) {
 	//prepare header
 	WS_frame_header_t hdr;
 	hdr.FIN = 0x1;
-	hdr.payload_length = length;
+	
 	hdr.mask = 0;
 	hdr.reserved = 0;
 	hdr.opcode = WS_OP_TXT;
+        
+        //determine length field type
+        if(length <= WS_STD_LEN)
+        {
+                hdr.payload_length = length;
+        } else if(length <= 0xFFFF) {
+                hdr.payload_length = 126;
+        } else {
+                hdr.payload_length = 127;
+        }
 
 	//send header
 	result = netconn_write(WS_conn, &hdr, sizeof(WS_frame_header_t), NETCONN_COPY);
@@ -95,6 +105,15 @@ err_t WS_write_data(char* p_data, size_t length) {
 	//check if header was send
 	if (result != ERR_OK)
 		return result;
+        
+        //send additional length field, if necessary
+        if(hdr.payload_length == 126)
+        {
+                char len = (length & 0xFF00) >> 8;
+                netconn_write(WS_conn, &len, 1, NETCONN_COPY);
+                len = length & 0x00FF;
+                netconn_write(WS_conn, &len, 1, NETCONN_COPY);
+        }
 
 	//send payload
 	return netconn_write(WS_conn, p_data, length, NETCONN_COPY);

--- a/main/WebSocket_Task.c
+++ b/main/WebSocket_Task.c
@@ -29,7 +29,7 @@
 #include "WebSocket_Task.h"
 
 #include "freertos/FreeRTOS.h"
-#include "esp_heap_alloc_caps.h"
+#include "esp_heap_caps.h"
 #include "hwcrypto/sha.h"
 #include "esp_system.h"
 #include "wpa2/utils/base64.h"
@@ -122,11 +122,10 @@ static void ws_server_netconn_serve(struct netconn *conn) {
 	WS_frame_header_t* p_frame_hdr;
 
 	//allocate memory for SHA1 input
-	p_SHA1_Inp = pvPortMallocCaps(WS_CLIENT_KEY_L + sizeof(WS_sec_conKey),
-			MALLOC_CAP_8BIT);
+	p_SHA1_Inp = malloc(WS_CLIENT_KEY_L + sizeof(WS_sec_conKey));
 
 	//allocate memory for SHA1 result
-	p_SHA1_result = pvPortMallocCaps(SHA1_RES_L, MALLOC_CAP_8BIT);
+	p_SHA1_result = malloc(SHA1_RES_L);
 
 	//Check if malloc suceeded
 	if ((p_SHA1_Inp != NULL) && (p_SHA1_result != NULL)) {
@@ -166,9 +165,7 @@ static void ws_server_netconn_serve(struct netconn *conn) {
 				free(p_SHA1_result);
 
 				//allocate memory for handshake
-				p_payload = pvPortMallocCaps(
-						sizeof(WS_srv_hs) + i - WS_SPRINTF_ARG_L,
-						MALLOC_CAP_8BIT);
+				p_payload = malloc(sizeof(WS_srv_hs) + i - WS_SPRINTF_ARG_L);
 
 				//check if malloc suceeded
 				if (p_payload != NULL) {
@@ -212,9 +209,7 @@ static void ws_server_netconn_serve(struct netconn *conn) {
 							if (p_frame_hdr->mask) {
 
 								//allocate memory for decoded message
-								p_payload = pvPortMallocCaps(
-										p_frame_hdr->payload_length + 1,
-										MALLOC_CAP_8BIT);
+								p_payload = malloc(p_frame_hdr->payload_length + 1);
 
 								//check if malloc succeeded
 								if (p_payload != NULL) {


### PR DESCRIPTION
#include "esp_heap_alloc_caps.h" is deprecated, replaced by
#include "esp_heap_caps.h"

pvPortMallocCaps(<size>, MALLOC_CAP_8BIT);
is equal to malloc, changed to malloc.
According to: https://esp-idf.readthedocs.io/en/latest/api-reference/system/mem_alloc.html#overview

